### PR TITLE
Automate issue labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -49,7 +49,7 @@ body:
     id: logs
     attributes:
       label: Relevant Log Output
-      description: Copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      description: Copy and paste any relevant log output.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -1,0 +1,50 @@
+name: "❌ Report a Bug"
+description: Create an issue if something does not work as expected.
+labels: ["Priority/Normal", "Type/Bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps you followed when you encountered the issue. If none, type N/A.
+    validations:
+      required: true
+  - type: input
+    id: affected
+    attributes:
+      label: Affected Component
+      description: |
+        Enter affected component and version in {component}-{version} format. For ex:- APIM-4.0.0. 
+        You can add multiple components each separated by a comma. For ex:- APIM-4.0.0,APICTL-4.0.0.
+        List of components = [Analytics, APIM, APICTL, IntegrationStudio, MI, MIDashboard, SI]
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Details (with versions)
+      description: Mention the environment details (OS, Client, etc.) that the product is running on.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: related
+    attributes:
+      label: Related Issues
+      description: Mention if any related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -1,4 +1,4 @@
-name: "❌ Report a Bug"
+name: "🐞 Report a Bug"
 description: Create an issue if something does not work as expected.
 labels: ["Priority/Normal", "Type/Bug"]
 body:
@@ -16,14 +16,26 @@ body:
       description: List the steps you followed when you encountered the issue. If none, type N/A.
     validations:
       required: true
-  - type: input
-    id: affected
+  - type: dropdown
+    id: component
     attributes:
       label: Affected Component
-      description: |
-        Enter affected component and version in {component}-{version} format. For ex:- APIM-4.0.0. 
-        You can add multiple components each separated by a comma. For ex:- APIM-4.0.0,APICTL-4.0.0.
-        List of components = [Analytics, APIM, APICTL, IntegrationStudio, MI, MIDashboard, SI]
+      description: Select affected component.
+      options:
+        - Analytics
+        - APICTL
+        - APIM
+        - IntegrationStudio
+        - MI
+        - MIDashboard
+        - SI
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Enter component version.
     validations:
       required: true
   - type: textarea
@@ -46,5 +58,12 @@ body:
     attributes:
       label: Related Issues
       description: Mention if any related issues.
+    validations:
+      required: false
+  - type: input
+    id: suggested
+    attributes:
+      label: Suggested Labels
+      description: Mention if any suggested labels.
     validations:
       required: false

--- a/.github/workflows/component_label_setter.yml
+++ b/.github/workflows/component_label_setter.yml
@@ -1,0 +1,24 @@
+on:
+  issues:
+    types: [opened]
+jobs:
+  set-affected-component-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: execute python script
+        run: |
+          python -m pip install requests
+          labels=`python .github/workflows/label_checker.py`
+          gh issue edit $ISSUE --add-label $labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}

--- a/.github/workflows/label_checker.py
+++ b/.github/workflows/label_checker.py
@@ -2,6 +2,7 @@ import os
 import requests
 
 # Get all existing labels in the repository
+labels = []
 all_existing_labels = []
 response = requests.get('https://api.github.com/repos/wso2/api-manager/labels', headers={"Accept": "application/vnd.github.v3+json"})
 if response.status_code == 200:
@@ -10,20 +11,20 @@ if response.status_code == 200:
 else:
     exit(0)
 
-# Get suggested labels for the issue
-i = os.environ["ISSUE_BODY"].index("### Affected Component") + 23
-j = os.environ["ISSUE_BODY"].index("### Environment Details (with versions)")
-suggested_labels = os.environ["ISSUE_BODY"][i:j].split(",")
+# Get affected component
+i = os.environ["ISSUE_BODY"].index("### Affected Component")
+j = os.environ["ISSUE_BODY"].index("### Version")
+component = os.environ["ISSUE_BODY"][i+23:j].strip()
+component_label = "Component/" + component
+if component_label in all_existing_labels:
+    labels.append(component_label)
 
-# Verify whether suggested labels are existing in the repository
-labels = []
-for label in suggested_labels:
-    affected_label = "Affected/" + label.strip()
-    component_label = "Component/" + label.strip().split("-")[0]
-    if affected_label in all_existing_labels:
-        labels.append(affected_label)
-    if component_label in all_existing_labels:
-        labels.append(component_label)
+# Get component version
+k = os.environ["ISSUE_BODY"].index("### Environment Details (with versions)")
+version = os.environ["ISSUE_BODY"][j+11:k].strip()
+affected_label = "Affected/" + component + "-" + version
+if affected_label in all_existing_labels:
+    labels.append(affected_label)
 
 # Return verified labels
 if len(labels) > 0:

--- a/.github/workflows/label_checker.py
+++ b/.github/workflows/label_checker.py
@@ -1,0 +1,32 @@
+import os
+import requests
+
+# Get all existing labels in the repository
+all_existing_labels = []
+response = requests.get('https://api.github.com/repos/wso2/api-manager/labels', headers={"Accept": "application/vnd.github.v3+json"})
+if response.status_code == 200:
+    for label in response.json():
+        all_existing_labels.append(label["name"])
+else:
+    exit(0)
+
+# Get suggested labels for the issue
+i = os.environ["ISSUE_BODY"].index("### Affected Component") + 23
+j = os.environ["ISSUE_BODY"].index("### Environment Details (with versions)")
+suggested_labels = os.environ["ISSUE_BODY"][i:j].split(",")
+
+# Verify whether suggested labels are existing in the repository
+labels = []
+for label in suggested_labels:
+    affected_label = "Affected/" + label.strip()
+    component_label = "Component/" + label.strip().split("-")[0]
+    if affected_label in all_existing_labels:
+        labels.append(affected_label)
+    if component_label in all_existing_labels:
+        labels.append(component_label)
+
+# Return verified labels
+if len(labels) > 0:
+    print(",".join(labels))
+else:
+    print("Missing/Component")

--- a/.github/workflows/resolution_label_notifier.yml
+++ b/.github/workflows/resolution_label_notifier.yml
@@ -1,0 +1,25 @@
+on:
+  issues:
+    types: [closed]
+jobs:
+  check-resolution-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if:
+      ${{!(
+      contains(github.event.issue.labels.*.name, 'Resolution/Cannot Reproduce') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Duplicate') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Fixed') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Answered') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Invalid') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Not a bug') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Postponed') ||
+      contains(github.event.issue.labels.*.name, 'Resolution/Won’t Fix')
+      )}}
+    steps:
+      - run: gh issue comment $ISSUE --body "This issue is **NOT** closed with a proper **Resolution/** label. Make sure to add proper reason label before closing. Please add or leave a comment with the proper reason label now.<br /><br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Cannot Reproduce** - Issue cannot be reproduced.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Duplicate** - Issue is already reported before.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Fixed** - Issue has already been fixed.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Answered** - Issue has already been answered.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Invalid** - Issue is invalid.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Not a bug** - Issue is not a bug.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Postponed** - Issue is postponed.<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- **Resolution/Won’t Fix** - Issue won't be fixed."
+      - run: gh issue reopen $ISSUE
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE: ${{ github.event.issue.html_url }}


### PR DESCRIPTION
This PR adds github action to add Affected and Component labels automatically which is retrieved from a github issue form. Also, it adds another action to warn if resolution label is not set and reopen the issue.

### New issue form looks like below.
![image](https://user-images.githubusercontent.com/36144069/170005046-39a0262c-3154-438a-a1e5-db1d411d7169.png)

### Warning message when resolution label is not set.
![image](https://user-images.githubusercontent.com/36144069/169799067-c20ac581-3249-4a5f-aa5b-caff6fbaba3c.png)

